### PR TITLE
Fixed an error & added arguments for scripts - v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     ],
     "warn-if-update-available": {
       "timeoutInDays": 7,
-      "message": "<%= chalk.rgb(229,193,0)(config.name) %> has a new update available: <%= chalk.greenBright(latest) %> (current version: <%= chalk.greenBright(config.version) %>).\nUpdate with <%= chalk.grayBright('npm run update') %> or <%= chalk.grayBright('yarn update') %>."
+      "message": "<%= chalk.rgb(229,193,0)(config.name) %> has a new update available: <%= chalk.greenBright(latest) %> (current version: <%= chalk.greenBright(config.version) %>).\nUpdate with <%= chalk.gray('npm run update') %> or <%= chalk.gray('yarn update') %>."
     }
   },
   "repository": "TheMrZZ/sandstone-cli",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sandstone-cli",
   "description": "The CLI for Sandstone - the data pack creation library.",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "author": "TheMrZZ - Florian ERNST",
   "bin": {
     "sand": "./bin/run"


### PR DESCRIPTION
Changelog:
- Fixed an error where using the CLI would display `chalk.grayBright isn't a function`
- Added 2 arguments for scripts: `dataPackName` & `destination`