### PR TITLE
Allow creating project in existing directory

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -126,7 +126,17 @@ export default class Create extends Command {
       })).useYarn === 'yarn'
     }
     
-    fs.mkdirSync(projectPath)
+    if (fs.existsSync(projectPath) && fs.statSync(projectPath).isDirectory()) {
+      const { overwrite }: { overwrite: string } = await inquirer.prompt({
+        name: 'overwrite',
+        message: 'The project directory you specified already exists, so some files might be changed/overwritten. Do you want to continue?',
+        type: 'list',
+        choices: ['Yes', 'No']
+      });
+      if (overwrite !== 'Yes') return;
+    } else { 
+      fs.mkdirSync(projectPath)
+    }
 
     // Create project & install dependencies
     this.log(chalk`Installing {rgb(229,193,0) sandstone}, {rgb(229,193,0) sandstone-cli} and {cyan typescript} using {cyan ${useYarn ? 'yarn' : 'npm'}}.`)

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -127,13 +127,12 @@ export default class Create extends Command {
     }
     
     if (fs.existsSync(projectPath) && fs.statSync(projectPath).isDirectory()) {
-      const { overwrite }: { overwrite: string } = await inquirer.prompt({
+      const { overwrite }: { overwrite: boolean } = await inquirer.prompt({
         name: 'overwrite',
         message: 'The project directory you specified already exists, so some files might be changed/overwritten. Do you want to continue?',
-        type: 'list',
-        choices: ['Yes', 'No']
+        type: 'confirm'
       });
-      if (overwrite !== 'Yes') return;
+      if (!overwrite) return;
     } else { 
       fs.mkdirSync(projectPath)
     }


### PR DESCRIPTION
Currently, if you want to create a project in an existing (or the current) directory, `fs` will throw an error and exit, as the cli is trying to create a directory that already exists. The changes I've made allow for you to run `npx sandstone-cli create .` to create a sandstone project in your current directory, for example.